### PR TITLE
Fix numpy and sklearn versions

### DIFF
--- a/mlops/london_taxi/environment/conda.yml
+++ b/mlops/london_taxi/environment/conda.yml
@@ -2,12 +2,13 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.9
   - pip
   - pip:
     - python-dotenv
     - pandas
-    - scikit-learn>=1.3.0
+    - numpy==1.23.5
+    - scikit-learn==1.3.2
     - mlflow>=2.9.2
     - azureml-mlflow>=1.53
     - azure-ai-ml>=1.10.0

--- a/mlops/nyc_taxi/environment/conda.yml
+++ b/mlops/nyc_taxi/environment/conda.yml
@@ -2,12 +2,13 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.9
   - pip
   - pip:
     - python-dotenv
     - pandas
-    - scikit-learn>=1.3.0
+    - numpy==1.23.5
+    - scikit-learn==1.3.2
     - mlflow>=2.9.2
     - azureml-mlflow>=1.53
     - azure-ai-ml>=1.10.0

--- a/model/london_taxi/batch_environment/conda.yml
+++ b/model/london_taxi/batch_environment/conda.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - pip:
     - pandas
-    - scikit-learn>=1.3.0
+    - numpy==1.23.5
+    - scikit-learn==1.3.2
     - azureml-core
     - azureml-dataset-runtime[fuse]

--- a/model/london_taxi/online_environment/conda.yml
+++ b/model/london_taxi/online_environment/conda.yml
@@ -2,11 +2,12 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.9
   - pip
   - pip:
     - pandas
-    - scikit-learn>=1.3.0
+    - numpy==1.23.5
+    - scikit-learn==1.3.2
     - mlflow>=2.9.2
     - azureml-mlflow>=1.53
     - azure-ai-ml>=1.10.0

--- a/model/nyc_taxi/batch_environment/conda.yml
+++ b/model/nyc_taxi/batch_environment/conda.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - pip:
     - pandas
-    - scikit-learn>=1.3.0
+    - numpy==1.23.5
+    - scikit-learn==1.3.2
     - azureml-core
     - azureml-dataset-runtime[fuse]

--- a/model/nyc_taxi/online_environment/conda.yml
+++ b/model/nyc_taxi/online_environment/conda.yml
@@ -2,11 +2,12 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.9
   - pip
   - pip:
     - pandas
-    - scikit-learn>=1.3.0
+    - numpy==1.23.5
+    - scikit-learn==1.3.2
     - mlflow>=2.9.2
     - azureml-mlflow>=1.53
     - azure-ai-ml>=1.10.0


### PR DESCRIPTION
The latest version of bumpy has a compatibility issue. It can lead to problems with environments and models. So, we are fixing versions and unify python version for training and inferencing (batch doesn't support the latest version of python, and we cannot use 3.12 anyway).