### PR TITLE
Fix get started reference in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The template contains the following documents:
 
 ## How to use the repo
 
-Information about how to setup the repo is in [the following document](./docs/getting_started.md).
+Information about how to setup the repo is in [the following document](./docs/how-to/GettingStarted.md).
 
 ## Local Execution
 


### PR DESCRIPTION
### What

The current main README references to an empty GettingStarted doc. Fixing this link

### Testing

Clicked on the updated hyperlink and got redirected to the right page