### PR TITLE
Workflows fail when branch name contains disallowed characters

### DIFF
--- a/mlops/common/naming_utils.py
+++ b/mlops/common/naming_utils.py
@@ -1,6 +1,8 @@
 """This module contains a few utility methods that generate names for for experiments, runs, models."""
+
 import subprocess
 import os
+import re
 
 
 def generate_experiment_name(model_name: str):
@@ -22,6 +24,7 @@ def generate_experiment_name(model_name: str):
         ).strip()
 
     git_branch = git_branch.split("/")[-1]
+    git_branch = re.sub(r"[^a-zA-Z0-9_-]+", "", git_branch)
     return f"{model_name}_{git_branch}"
 
 


### PR DESCRIPTION
AML experiment / job names are constructed using the PR's branch name. AML enforces naming requirements on experiment names. When the PR's branch contains disallowed characters, the AML job and workflow fails with the following error:

Microsoft.RelInfra.Common.Exceptions.ErrorResponseException: Experiment name must be 1-256 characters, start with a letter or a number, and can only contain letters, numbers, underscores, and dashes.

Closes #179 